### PR TITLE
modification to get correct function definition status

### DIFF
--- a/src/FlexSeleniumLibrary/sfapicommands.py
+++ b/src/FlexSeleniumLibrary/sfapicommands.py
@@ -76,6 +76,8 @@ class SeleniumFlexAPICommands(object):
             return False
         if "{}()".format(function_name) in result:
             return True
+        if isinstance(result, (dict, list)) and len(result) == 0:  # firefox/chrome return empty dict, IE return
+            return True                                            # empty list via latest webdriver 20170312.
         raise AssertionError("Unknown result for function existence: {}".format(result))
 
     def do_flex_add_select_index(self, element_id, index):


### PR DESCRIPTION
I did little modification based on latest webdriver behavior. 
They returned empty dict/list even functions are actually defined. 
None value is still returned if function not defined.

Firefox
![webdriverfirefox_return_emptydict](https://cloud.githubusercontent.com/assets/15623802/23824468/c20179aa-06ba-11e7-8964-af1887d0da59.png)

IE
![webdriverie_return_emptylist](https://cloud.githubusercontent.com/assets/15623802/23824469/c221b530-06ba-11e7-85a1-02f57ed70ef4.png)

Chrome:
![webdriverchrome_return_emptydict](https://cloud.githubusercontent.com/assets/15623802/23824470/c23c1218-06ba-11e7-82ee-937dbf794a54.png)
