### PR TITLE
open with "about:blank" to avoid exception on firefox

### DIFF
--- a/test/unit/test.py
+++ b/test/unit/test.py
@@ -33,7 +33,7 @@ class TestCases(unittest.TestCase):
     def setUpClass(cls):
         cls.flex_selenium = FlexSeleniumLibrary(application_name, api_version, sleep_after_call, sleep_after_fail,
                                                 number_of_retries, ensure_timeout)
-        cls.flex_selenium.open_browser("")
+        cls.flex_selenium.open_browser("about:blank")
         cls.flex_selenium.maximize_browser_window()
 
     @classmethod


### PR DESCRIPTION
err trace of opening empty url with firefox
![error_openbrowser](https://cloud.githubusercontent.com/assets/15623802/23824703/8f0b4d1a-06be-11e7-97bd-9e0c460cd830.png)
